### PR TITLE
JIRA:K8S-505 Update haproxy config for mdns

### DIFF
--- a/playbooks/group_vars/designate_all.yml
+++ b/playbooks/group_vars/designate_all.yml
@@ -58,7 +58,7 @@ designate_package_state: "{{ package_state }}"
 designate_venv_tag: "{{ venv_tag }}"
 designate_venv_download_url: "{{ venv_base_download_url }}/designate-{{ openstack_release }}-{{ ansible_architecture | lower }}.tgz"
 
-haproxy_extra_services:
+haproxy_service_configs:
   - service:
       haproxy_service_name: designate_api
       haproxy_backend_nodes: "{{ groups['designate_all'] | default([]) }}"
@@ -70,9 +70,6 @@ haproxy_extra_services:
   - service:
       haproxy_service_name: designate_mdns
       haproxy_backend_nodes: "{{ groups['designate_all'] | default([]) }}"
-      haproxy_ssl: "{{ haproxy_ssl }}"
       haproxy_port: 5354
-      haproxy_balance_type: http
-      haproxy_backend_options:
-        - "httpchk GET /"
+      haproxy_balance_type: tcp
 


### PR DESCRIPTION
The mdns needs a tcp load balancer type instead of the http type that was defined.