### PR TITLE
JIRA:K8S-524 Create playbook for iptables rules for designate-mdns

### DIFF
--- a/playbooks/group_vars/designate_all.yml
+++ b/playbooks/group_vars/designate_all.yml
@@ -67,9 +67,4 @@ haproxy_service_configs:
       haproxy_balance_type: http
       haproxy_backend_options:
         - "httpchk GET /"
-  - service:
-      haproxy_service_name: designate_mdns
-      haproxy_backend_nodes: "{{ groups['designate_all'] | default([]) }}"
-      haproxy_port: 5354
-      haproxy_balance_type: tcp
 

--- a/playbooks/setup-infra-firewall-mdns.yml
+++ b/playbooks/setup-infra-firewall-mdns.yml
@@ -1,0 +1,41 @@
+# Copyright 2014-2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+- name: Setup iptables rules for designate-mdns
+  hosts: designate_all
+  tasks:
+  - name: Enable forwarding for port mdns server
+    iptables:
+      chain: FORWARD
+      in_interface: "{{ management_bridge }}"
+      protocol: udp
+      destination_port: 5354
+      ctstate: NEW,ESTABLISHED
+      jump: ACCEPT
+    delegate_to: "{{ physical_host }}"
+  
+  - name: Define PREROUTING DNAT for mdns server
+    iptables:
+      table: nat
+      chain: PREROUTING
+      in_interface: "{{ management_bridge }}"
+      protocol: "{{ item }}"
+      destination_port: 5354
+      jump: DNAT
+      to_destination: "{{ ansible_default_ipv4['address']}}"
+    delegate_to: "{{ physical_host }}"
+    with_items:
+      - tcp
+      - udp

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -45,6 +45,9 @@ run_ansible ${DESIGNATE_DEPLOY_OPS} -e "designate_developer_mode=True" /opt/rpc-
 # add service to haproxy
 run_ansible ${DESIGNATE_DEPLOY_OPS} haproxy-install.yml 
 
+# open ports for designate-mdns
+run_ansible ${DESIGNATE_DEPLOY_OPS} /opt/rpc-designate/playbooks/setup-infra-firewall-mdns.yml
+
 # add filebeat to service so we get logging
 cd /opt/rpc-openstack/
 run_ansible /opt/rpc-openstack/rpcd/playbooks/filebeat.yml --limit designate_all


### PR DESCRIPTION
Since the designate-mdns server needs to communicate with bidirectionally with
the "customers" name server there should be ports opened up so the external name
servers can talk directly to the designate-mdns service. Since some of this communication
takes place over UDP we can't use haproxy for the port forwarding/load balancing