### PR TITLE
K8S-556: Install BIND9Utils to Designate containers

### DIFF
--- a/playbooks/os-designate-install.yml
+++ b/playbooks/os-designate-install.yml
@@ -16,14 +16,17 @@
   hosts: "{{ lxc_host_group | default('lxc_hosts')}}"
   gather_facts: "{{ gather_facts | default(True) }}"
 
-- name: Install Git in the containers
+- name: Install additional packages
   hosts: designate_all
   user: root
   tasks:
-    - name: Install git
+    - name: Install packages
       apt: 
-        name: git
+        name: "{{ item }}"
         state: installed
+      with_items:
+        - "git"
+        - "bind9utils"
 
 - name: Install Designate Server
   hosts: designate_all


### PR DESCRIPTION
For AIO testing we need to install the rndc utility into the Designate containers so the worker can communicate with the bind service running on the host.