### PR TITLE
Symlink post-merge test to pre-merge

### DIFF
--- a/gating/post_merge_test
+++ b/gating/post_merge_test
@@ -1,0 +1,1 @@
+pre_merge_test


### PR DESCRIPTION
The directory gating/post_merge_test is required for post-merge
(periodic) jobs.  This commit simply symlinks post_merge_test to the
existing pre_merge_test directory.