### PR TITLE
RE-36 Don't fail on pike tests

### DIFF
--- a/gating/scripts/pre.sh
+++ b/gating/scripts/pre.sh
@@ -40,7 +40,9 @@ case $RE_JOB_SCENARIO in
   ;;
 "pike")
   # Right now since we don't have the pike code included, just exit
+  echo "Pre gate job ended prematurely, pike not yet implemented"
   exit
+  ;;
 esac
 
 # Clone rpc-openstack

--- a/gating/scripts/run.sh
+++ b/gating/scripts/run.sh
@@ -25,11 +25,21 @@ echo "+-------------------- START ENV VARS --------------------+"
 env
 echo "+-------------------- START ENV VARS --------------------+"
 
-# Run tests
-echo "RUN DESIGNATE. TESTS"
-openstack-ansible ${MY_BASE_DIR}/gating/scripts/test_designate.yml \
-                  -e working_dir=${MY_BASE_DIR} \
-                  -e rpc_release=${RPC_RELEASE} \
-                  ${ANSIBLE_PARAMETERS}
+# Setup a few variables specific to the scenario that we are running
+case $RE_JOB_SCENARIO in
+"newton")
+  # Run tests
+  echo "RUN DESIGNATE. TESTS"
+  openstack-ansible ${MY_BASE_DIR}/gating/scripts/test_designate.yml \
+                    -e working_dir=${MY_BASE_DIR} \
+                    -e rpc_release=${RPC_RELEASE} \
+                    ${ANSIBLE_PARAMETERS}
+  ;;
+"pike")
+  # Right now since we don't have the pike code included, just exit
+  echo "Gate gate job ended prematurely, pike not yet implemented"
+  exit
+  ;;
+esac
 
 echo "Gate job ended"


### PR DESCRIPTION
At present, pike jobs fail because setup is skipped in scripts/pre.sh
but ansible will still run in scripts/run.sh, despite designate not
being setup.

This commit simply adds a similar case statement to scripts/run.sh to
skip executing ansible when RE_JOB_SCENARIO is set to "pike".