### PR TITLE
RI-218: Remove AIO flag for bind deployment

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -33,10 +33,7 @@ fi
 # Perform peliminary configurations for Designate
 setup_designate 
 deploy_container
-# If we are running and AIO, deploy the local name server
-if [[ "${DEPLOY_AIO}" == "yes" ]]; then
-  deploy_bind
-fi
+deploy_bind
 
 # Install Designate
 deploy_designate


### PR DESCRIPTION
If you didn't have the DEPLOY_AIO flag set in the environemnt the deployment script would skip over the bind installation. Removed the if statement so that bind is always deployed.