### PR TITLE
RI-225: Update gate code to deploy against proper RPC-O Branch

### DIFF
--- a/gating/scripts/functions.sh
+++ b/gating/scripts/functions.sh
@@ -19,7 +19,27 @@ clone_openstack() {
   fi
 }
 
+gate_determine_branch() {
+  # Depending on the branch that we are using it could make a difference on what version version
+  # of openstack that we need to deploy against. The branch can be determined by looking at the 
+  # RE_JOB_BRANCH variable. If the RE_JOB_BRANCH is not set as in the PreMerge Jobs lets set a defult
+  # to use master as the branch as that would be were we are doing to development
+  export RE_JOB_BRANCH=${RE_JOB_BRANCH:-master}
+  if [ ${RE_JOB_BRANCH} == 'master' ]; then
+    export RPC_RELEASE=${RE_JOB_SCENARIO}
+  elif [ ${RE_JOB_BRANCH} == 'master-rc' ]; then
+    export RPC_RELEASE="${RE_JOB_SCENARIO}-rc"
+  fi
+}
+
 gate_deploy_pike() {
+  # As a gating requirement we need to make sure that the pyhon-yaml packages are installed
+  # so we can read the version of the release
+  dpkg-query -l python-yaml > /dev/null
+  if [[ $? -eq 1 ]]; then
+    apt-get -y install python-yaml
+  fi
+ 
   # for now we are just going to deploy using the deployment script
   cd ${OS_BASE_DIR}
   scripts/deploy.sh

--- a/gating/scripts/pre.sh
+++ b/gating/scripts/pre.sh
@@ -26,21 +26,26 @@ echo "+-------------------- START ENV VARS --------------------+"
 env
 echo "+-------------------- START ENV VARS --------------------+"
 
+
+
 # If we're not using a pre-saved rpc-openstack image, then deploy the
 # necessary OpenStack infrastructure and services.
 if [[ ! ${RE_JOB_IMAGE} =~ _snapshot$ ]]; then
 
+  # Install required prerequisites
+  apt-get -y install python-yaml
+
   case $RE_JOB_SCENARIO in
   "newton")
     # Pin RPC-Release to 14.3 for newton
-    export RPC_RELEASE=${RPC_NEWTON_RELEASE}
+    gate_determine_branch
     export RPC_PRODUCT_RELEASE=${RE_JOB_SCENARIO}
     export OSA_BASE_DIR=${OS_BASE_DIR}/openstack-ansible
     clone_openstack
     gate_deploy_newton
   ;;
   "pike")
-    export RPC_RELEASE=${RPC_PIKE_RELEASE}
+    gate_determine_branch
     export RPC_PRODUCT_RELEASE=${RE_JOB_SCENARIO}
     export OSA_BASE_DIR=${OS_BASE_DIR}/openstack-ansible
     clone_openstack

--- a/gating/scripts/vars.sh
+++ b/gating/scripts/vars.sh
@@ -36,14 +36,3 @@ export ANSIBLE_ROLE_FETCH_MODE="git-clone"
 # To provide flexibility in the jobs, we have the ability to set any
 # parameters that will be supplied on the ansible-playbook CLI.
 export ANSIBLE_PARAMETERS=${ANSIBLE_PARAMETERS:--v}
-
-# If RE_JOB_SCENARIO is set to functional, we need to change it to newton
-if [ ${RE_JOB_SCENARIO} == 'functional' ]; then
-  export RE_JOB_SCENARIO="newton"
-fi
-
-# Pin the newton version of rpc-openstack
-export RPC_NEWTON_RELEASE="r14.3.0"
-
-# Pin the pike version of rpc-openstack
-export RPC_PIKE_RELEASE="r16.0.0"


### PR DESCRIPTION
Update the gating script to use different branches of rpc-openstack depending on the branch that is being tested against. When you run a gate test on one of the rc braches, it will run all tests against the release candidate branch of either pike or Newton depending on the test that is being run. 