### PR TITLE
Ensure the apt cache is updated before installing BIND

### DIFF
--- a/playbooks/setup-bind-apt.yml
+++ b/playbooks/setup-bind-apt.yml
@@ -15,27 +15,44 @@
 # With the apt package it will install a rndc key so we dont need to generate one
 
 ---
-- name: Install Bind
-  apt:
-    name: bind9
-    state: present
-  register: bind_installed
-  ignore_errors: yes
+- block:
+    - name: Update the apt cache
+      apt:
+        update_cache: yes
+        cache_valid_time: "{{ (cache_timeout is defined) | ternary(cache_timeout, omit) }}"
+      register: update_apt_cache
+      until: update_apt_cache | success
+      retries: 5
+      delay: 2
 
-- name: Install BIND fallback method
-  command: sudo apt-get install -y bind9
-  when: bind_installed | failed
-  
+    - name: Install BIND (primary method)
+      apt:
+        name: bind9
+        state: present
+      register: install_packages
+      until: install_packages | success
+      retries: 5
+      delay: 2
+  rescue:
+    - name: Install BIND (fallback method)
+      command: |
+        apt-get update
+        apt-get install -y bind9
+      register: install_packages
+      until: install_packages | success
+      retries: 5
+      delay: 2
+
 - name: Install named configuration file
-  template: 
+  template:
     src: ../files/named.conf.j2
     dest: /etc/bind/named.conf.options
     owner: root
     group: root
   notify: Restart BIND
-    
+
 - name: Create needed directories
-  file: 
+  file:
     name: "{{ item }}"
     group: "bind"
     mode: 0775
@@ -44,9 +61,9 @@
     - "/var/cache/bind/data"
     - "/var/cache/bind/dynamic"
   notify: Restart BIND
-  
-- name: Start bind 
-  service: 
+
+- name: Start bind
+  service:
     name: bind9
     enabled: yes
     state: started

--- a/playbooks/setup-bind.yml
+++ b/playbooks/setup-bind.yml
@@ -39,7 +39,7 @@
       service:
         name: bind9
         state: restarted
-        
+
 
 - name: Install rndc.key
   hosts: designate_all
@@ -59,9 +59,30 @@
     # The designate container will be missing the rndc executable
     # this needs to be installed so we can communicate with bind
     # nameservers
-    - name: Install packages
-      apt:
-        name: "{{ item }}"
-        state: installed
-      with_items:
-        - "bind9utils"
+    - block:
+        - name: Update the apt cache
+          apt:
+            update_cache: yes
+            cache_valid_time: "{{ (cache_timeout is defined) | ternary(cache_timeout, omit) }}"
+          register: update_apt_cache
+          until: update_apt_cache | success
+          retries: 5
+          delay: 2
+
+        - name: Install BIND Utils (primary method)
+          apt:
+            name: bind9utils
+            state: present
+          register: install_packages
+          until: install_packages | success
+          retries: 5
+          delay: 2
+      rescue:
+        - name: Install BIND Utils (fallback method)
+          command: |
+            apt-get update
+            apt-get install -y bind9utils
+          register: install_packages
+          until: install_packages | success
+          retries: 5
+          delay: 2


### PR DESCRIPTION
The apt cache may be out of date, so to ensure that it is
fresh, we force the update. We also implement a try/rescue
block rather than using ignore_failure as that is a more
appropriate way to do a fallback method for Ansible 2.x
onwards.

We do not use the 'name' keyword for 'block' because that
was only made available in Ansible 2.3, and these playbooks
need to work with newton, which is Ansible 2.1.

JIRA: RI-480